### PR TITLE
Update docs.coffee, default doc version

### DIFF
--- a/scripts/docs.coffee
+++ b/scripts/docs.coffee
@@ -13,7 +13,7 @@
 cheerio   = require 'cheerio'
 htmlStrip = require 'htmlstrip-native'
 
-TARGET_VERSION = 'master'
+TARGET_VERSION = 5
 SEARCH_URL = 'https://www.google.com/search'
 USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.116 Safari/537.36'
 #Rommie=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17
@@ -21,7 +21,7 @@ USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Ge
 module.exports = (robot) ->
   getQueryUrl = (doctype, version, query) ->
     version = 3 if version?.match /^3(.*)/i
-    version = 'master' if version?.match /^5(.*)/i
+    version = 5 if version?.match /^5(.*)/i
 
     if doctype == 'api'
       if version == 3


### PR DESCRIPTION
Change default version to 5 instead of master now that google has indexed all the doc versions.