### PR TITLE
Update youtube script for API v3

### DIFF
--- a/scripts/youtube.coffee
+++ b/scripts/youtube.coffee
@@ -7,22 +7,22 @@ module.exports = (robot) ->
   robot.respond /(youtube|yt)( me)?( -)? (.*)/i, (msg) ->
     norandom = msg.match[3]?
     query = msg.match[4]
-    robot.http("http://gdata.youtube.com/feeds/api/videos")
+    robot.http("https://www.googleapis.com/youtube/v3/search")
       .query({
-        orderBy: "relevance"
-        'max-results': 15
-        alt: 'json'
+        key: process.env.HUBOT_YOUTUBE_KEY
+        part: "id"
+        type: "video"
+        order: "relevance"
+        maxResults: 15
         q: query
       })
       .get() (err, res, body) ->
-        videos = JSON.parse(body)
-        videos = videos.feed.entry
+        result = JSON.parse(body)
+        videos = result.items
 
         unless videos?
           msg.send "No video results for \"#{query.substr(0,30)}\""
           return
 
         video = if norandom then videos[0] else msg.random videos
-        video.link.forEach (link) ->
-          if link.rel is "alternate" and link.type is "text/html"
-            msg.send link.href
+        msg.send "https://youtu.be/" + video.id.videoId


### PR DESCRIPTION
Starting yesterday, [Google have begun](https://support.google.com/youtube/answer/6098135?p=yt_devicesupport&hl=en-GB&rd=1) to [kill off the old v2 API](http://youtube-eng.blogspot.co.uk/2014/03/committing-to-youtube-data-api-v3_4.html). Because of this, Liona will sometimes link to a [device support video](https://www.youtube.com/watch?v=UKY3scPIMd8&feature=youtube_gdata) instead of the requested video.

This PR updates the youtube script to be compatible with version 3 of the API, but it also has a downside. You can no longer use it without an API key. These steps should get you sorted:

1. Create a project in [the Developer Console](https://console.developers.google.com/project)
2. Activate the Youtube Data API for the new project
3. Head to APIs & Auth > Credentials and `Create new Key`
4. Paste in the IP address that Liona lives behind
5. Define your API key in the start script or wherever you set your env vars:
    `HUBOT_YOUTUBE_KEY="your_api_key"`

We seem to get 50 _million_ quota "credits" per day on a normal account. Since the `search` endpoint only uses 50 credits per request, you should be pretty safe. Probably.